### PR TITLE
Alignment with RFC 7516 and 7518

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -15,8 +15,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - 4
-          - 5
+          - 4.14.x
+          - 5.3.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.27.0
+version = 0.29.0
 
 wrap-comments = false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
-0.10.1
+0.11.0
 --------------
 - Add `kid` to output ed25519 json representation as this was missed when implementing it. Reported by @patricoferris, fixed by @ulrikstrid.
+- Correct IV length `enc` is A256GCM
+- We had some potential for raising in our unpad function
+- Constant time string comparison everywhere
+- Fix a bug in RSA validation
 
 0.10.0
 --------------

--- a/jose/Jose.ml
+++ b/jose/Jose.ml
@@ -5,3 +5,7 @@ module Jwt = Jwt
 module Jwa = Jwa
 module Header = Header
 module Jwe = Jwe
+
+module Private = struct
+  module Utils = Utils
+end

--- a/jose/Jose.mli
+++ b/jose/Jose.mli
@@ -462,3 +462,55 @@ module Jwe : sig
   (** [decrypt jwk string] decrypts a compact string formated JWE into a {! t }
   *)
 end
+
+module Private : sig
+  module Utils : sig
+    module U_Result : sig
+      val all8 :
+        ('a, 'b) result ->
+        ('c, 'd) result ->
+        ('e, 'f) result ->
+        ('g, 'h) result ->
+        ('i, 'j) result ->
+        ('k, 'l) result ->
+        ('m, 'n) result ->
+        ('o, 'p) result ->
+        ('a * 'c * 'e * 'g * 'i * 'k * 'm * 'o, [> `Msg of string ]) result
+    end
+
+    module U_String : sig
+      val rev : string -> string
+      val pad : c:char -> len:int -> string -> string
+      val trim_leading_null : string -> string
+      val split : string -> int -> string * string
+    end
+
+    module U_Base64 : sig
+      val url_encode_string : ?pad:bool -> string -> string
+
+      val url_encode :
+        ?pad:bool ->
+        ?off:int ->
+        ?len:int ->
+        string ->
+        (string, [> `Msg of string ]) result
+
+      val url_decode :
+        ?pad:bool ->
+        ?off:int ->
+        ?len:int ->
+        string ->
+        (string, [> `Msg of string ]) result
+    end
+
+    module RJson : sig
+      val to_json_string_opt :
+        'a -> 'b option -> ('a * [> `String of 'b ]) option
+    end
+
+    module Pkcs7 : sig
+      val pad : string -> int -> string
+      val unpad : string -> (string, [> `Msg of string ]) result
+    end
+  end
+end

--- a/jose/Jose.mli
+++ b/jose/Jose.mli
@@ -3,12 +3,14 @@
     {{:https://www.tools.ietf.org/rfc/rfc7518.html} Link to RFC} *)
 module Jwa : sig
   type alg =
-    [ `RS256  (** HMAC using SHA-256 *)
-    | `HS256  (** RSASSA-PKCS1-v1_5 using SHA-256 *)
+    [ `RS256  (** RSASSA-PKCS1-v1_5 using SHA-256 *)
+    | `HS256  (** HMAC using SHA-256 *)
     | `ES256  (** ECDSA using P-256 and SHA-256 *)
     | `ES384  (** ECDSA using P-384 and SHA-384 *)
     | `ES512  (** ECDSA using P-521 and SHA-512 *)
     | `EdDSA
+        (** EdDSA signature algorithm
+            {{:https://www.rfc-editor.org/rfc/rfc8037.html} Link to RFC} *)
     | `RSA_OAEP  (** RSAES OAEP using default parameters *)
     | `RSA1_5  (** RSA PKCS 1 *)
     | `None
@@ -242,7 +244,7 @@ module Jwk : sig
       following {{:https://tools.ietf.org/html/rfc7638} RFC 7638}.
 
       Returns an error for symmetric keys: sharing the hash may leak information
-      about the key itself ans it's deemed unsafe. *)
+      about the key itself and it's deemed unsafe. *)
 
   val use_to_string : use -> string
   val use_of_string : string -> use

--- a/jose/Jwa.ml
+++ b/jose/Jwa.ml
@@ -20,12 +20,12 @@ let kty_of_string : string -> kty = function
   | str -> `Unsupported str
 
 type alg =
-  [ `RS256  (** HMAC using SHA-256 *)
-  | `HS256  (** RSASSA-PKCS1-v1_5 using SHA-256 *)
+  [ `RS256  (** RSASSA-PKCS1-v1_5 using SHA-256 *)
+  | `HS256  (** HMAC using SHA-256 *)
   | `ES256  (** ECDSA using P-256 and SHA-256 *)
   | `ES384  (** ECDSA using P-384 and SHA-384 *)
   | `ES512  (** ECDSA using P-521 and SHA-512 *)
-  | `EdDSA  (**  *)
+  | `EdDSA  (** EdDSA signature algorithm *)
   | `RSA_OAEP  (** RSAES OAEP using default parameters *)
   | `RSA1_5  (** RSA PKCS 1 *)
   | `None

--- a/jose/Jwa.ml
+++ b/jose/Jwa.ml
@@ -75,3 +75,8 @@ let enc_of_string enc =
   | _ -> raise Not_found
 
 let enc_to_length = function `A128CBC_HS256 -> 256 | `A256GCM -> 256
+
+let enc_to_iv_length = function
+  | `A128CBC_HS256 -> Mirage_crypto.AES.CBC.block_size
+  (* https://www.rfc-editor.org/info/rfc7518/#section-5.3 12*8 = 96 bits*)
+  | `A256GCM -> 12

--- a/jose/Jwe.ml
+++ b/jose/Jwe.ml
@@ -175,7 +175,7 @@ let decrypt_ciphertext enc ~cek ~iv ~auth_tag ~aad ciphertext =
             (* B.7 truncate to 128 bit *)
             String.sub (Digestif.SHA256.to_raw_string full) 0 16
           in
-          if not (String.equal computed_auth_tag auth_tag) then
+          if not (Eqaf.equal computed_auth_tag auth_tag) then
             Error (`Msg "invalid auth tag")
           else
             (* B.2 encryption in CBC mode *)

--- a/jose/Jwe.ml
+++ b/jose/Jwe.ml
@@ -34,11 +34,9 @@ let make_cek (header : Header.t) =
   | None -> Error `Missing_enc
 
 let make_iv (header : Header.t) =
-  match header.alg with
-  | `RSA_OAEP ->
-      Ok (Mirage_crypto_rng.generate Mirage_crypto.AES.GCM.block_size)
-  | `RSA1_5 -> Ok (Mirage_crypto_rng.generate Mirage_crypto.AES.CBC.block_size)
-  | _ -> Error `Unsupported_alg
+  match header.enc with
+  | Some enc -> Ok (Mirage_crypto_rng.generate @@ Jwa.enc_to_iv_length enc)
+  | None -> Error `Missing_enc
 
 let make ~header payload =
   let cek = make_cek header in

--- a/jose/Utils.ml
+++ b/jose/Utils.ml
@@ -59,11 +59,15 @@ module Pkcs7 = struct
 
   let unpad cs =
     let cs_len = String.length cs in
-    let pad_len = String.get_uint8 cs (cs_len - 1) in
-    let data, padding = U_String.split cs (cs_len - pad_len) in
-    let rec check idx =
-      if idx >= pad_len then true
-      else String.get_uint8 padding idx = pad_len && check (idx + 1)
-    in
-    if check 0 then Ok data else Error (`Msg "bad padding")
+    if cs_len = 0 then Error (`Msg "bad padding")
+    else
+      let pad_len = String.get_uint8 cs (cs_len - 1) in
+      if pad_len = 0 || pad_len > cs_len then Error (`Msg "bad padding")
+      else
+        let data, padding = U_String.split cs (cs_len - pad_len) in
+        let rec check idx =
+          if idx >= pad_len then true
+          else String.get_uint8 padding idx = pad_len && check (idx + 1)
+        in
+        if check 0 then Ok data else Error (`Msg "bad padding")
 end

--- a/test/RFC7516.ml
+++ b/test/RFC7516.ml
@@ -1,0 +1,75 @@
+(* Tests for RFC 7516 (JSON Web Encryption) and related JWA RFC 7518 algorithms *)
+let () = Mirage_crypto_rng_unix.use_default ()
+
+open Helpers
+
+let rsa_priv_jwk =
+  Fixtures.rsa_priv_enc_json |> Jose.Jwk.of_priv_json_string |> CCResult.get_exn
+
+let jwe_tests =
+  ( "RFC7516",
+    [
+      Alcotest.test_case "IV length is determined by enc (CBC vs GCM)" `Quick
+        (fun () ->
+          (* RSA-OAEP paired with CBC must use 16 bytes *)
+          let header_cbc =
+            Jose.Header.make_header ~alg:`RSA_OAEP ~enc:`A128CBC_HS256
+              rsa_priv_jwk
+          in
+          let jwe_cbc =
+            Jose.Jwe.make ~header:header_cbc "secret message"
+            |> CCResult.get_exn
+          in
+          Alcotest.(check int)
+            "CBC IV length must be 16 bytes" 16 (String.length jwe_cbc.iv);
+
+          (* RSA1_5 paired with GCM must use 12 bytes (96 bits) *)
+          let header_gcm =
+            Jose.Header.make_header ~alg:`RSA1_5 ~enc:`A256GCM rsa_priv_jwk
+          in
+          let jwe_gcm =
+            Jose.Jwe.make ~header:header_gcm "secret message"
+            |> CCResult.get_exn
+          in
+          Alcotest.(check int)
+            "GCM IV length must be 12 bytes" 12 (String.length jwe_gcm.iv));
+      Alcotest.test_case
+        "PKCS#7 unpadding gracefully handles corrupted padding without \
+         exception"
+        `Quick (fun () ->
+          let header =
+            Jose.Header.make_header ~alg:`RSA_OAEP ~enc:`A128CBC_HS256
+              rsa_priv_jwk
+          in
+          let jwe =
+            Jose.Jwe.make ~header "test payload"
+            |> CCResult.get_exn
+            |> Jose.Jwe.encrypt ~jwk:rsa_priv_jwk
+            |> CCResult.get_exn
+          in
+          (* Tamper with ciphertext by corrupting bytes *)
+          let segs = String.split_on_char '.' jwe in
+          let corrupted_jwe =
+            String.concat "."
+              [
+                List.nth segs 0;
+                List.nth segs 1;
+                List.nth segs 2;
+                url_encode_string "\x00\x00\x00\x00\x00\x00\x00\x00";
+                List.nth segs 4;
+              ]
+          in
+          let raised =
+            try
+              let _ = Jose.Jwe.decrypt ~jwk:rsa_priv_jwk corrupted_jwe in
+              false
+            with Invalid_argument _ -> true
+          in
+          Alcotest.(check bool)
+            "decrypt must return Result.Error and not throw Invalid_argument \
+             exception"
+            false raised);
+    ] )
+
+let suite, _ =
+  Junit_alcotest.run_and_report ~package:"jose" "RFC7516" [ jwe_tests ]

--- a/test/RFC7518.ml
+++ b/test/RFC7518.ml
@@ -1,0 +1,55 @@
+(* Tests for RFC 7518 (JSON Web Algorithms) *)
+let () = Mirage_crypto_rng_unix.use_default ()
+let rsa_priv = Jose.Jwk.of_priv_pem Fixtures.rsa_test_priv |> CCResult.get_exn
+let rsa_pub = Jose.Jwk.pub_of_priv rsa_priv
+let oct_jwk = Jose.Jwk.make_oct "my-secret-key-384-512-testing"
+
+let rsa_priv_jwk =
+  Fixtures.rsa_priv_enc_json |> Jose.Jwk.of_priv_json_string |> CCResult.get_exn
+
+let jwa_tests =
+  ( "RFC7518",
+    [
+      Alcotest.test_case "3.1: ES256 (Recommended+) signing and validation"
+        `Quick (fun () ->
+          let es256_priv =
+            Jose.Jwk.of_priv_pem Fixtures.es256_test_priv |> CCResult.get_exn
+          in
+          let es256_pub = Jose.Jwk.pub_of_priv es256_priv in
+          let header = Jose.Header.make_header ~alg:`ES256 es256_priv in
+          let payload = "hello ES256 RFC 7518" in
+          let jws =
+            Jose.Jws.sign ~header ~payload es256_priv |> CCResult.get_exn
+          in
+          let validated = Jose.Jws.validate ~jwk:es256_pub jws in
+          Alcotest.(check bool) "ES256 signature validates with public key" true
+            (CCResult.is_ok validated);
+          let tampered_jws = { jws with payload = "tampered payload" } in
+          let res_tampered = Jose.Jws.validate ~jwk:es256_pub tampered_jws in
+          Alcotest.(check bool) "ES256 validation fails on tampered payload" true
+            (CCResult.is_error res_tampered));
+      Alcotest.test_case "4.1: RSA-OAEP-256 key management support in JWE"
+        `Quick (fun () ->
+          let header_json =
+            `Assoc
+              [ ("alg", `String "RSA-OAEP-256"); ("enc", `String "A256GCM") ]
+          in
+          let header = Jose.Header.of_json header_json |> CCResult.get_exn in
+          let jwe_res = Jose.Jwe.make ~header "secret payload" in
+          Alcotest.(check bool)
+            "Jwe.make succeeds with RSA-OAEP-256" true (CCResult.is_ok jwe_res));
+      Alcotest.test_case "5.3: A256GCM IV length is 96 bits (12 bytes)" `Quick
+        (fun () ->
+          let header =
+            Jose.Header.make_header ~alg:`RSA_OAEP ~enc:`A256GCM rsa_priv_jwk
+          in
+          let jwe =
+            Jose.Jwe.make ~header "secret message" |> CCResult.get_exn
+          in
+          Alcotest.(check int)
+            "A256GCM IV length must be 12 bytes (96 bits)" 12
+            (String.length jwe.iv));
+    ] )
+
+let suite, _ =
+  Junit_alcotest.run_and_report ~package:"jose" "RFC7518" [ jwa_tests ]

--- a/test/UtilsTest.ml
+++ b/test/UtilsTest.ml
@@ -1,0 +1,97 @@
+(* Tests for Jose.Private.Utils *)
+module Utils = Jose.Private.Utils
+module Pkcs7 = Utils.Pkcs7
+module U_String = Utils.U_String
+module U_Base64 = Utils.U_Base64
+
+let pkcs7_tests =
+  ( "Pkcs7",
+    [
+      Alcotest.test_case
+        "unpad empty string returns Error without raising exception" `Quick
+        (fun () ->
+          let raised, res =
+            try (false, Pkcs7.unpad "")
+            with e -> (true, Error (`Msg (Printexc.to_string e)))
+          in
+          Alcotest.(check bool) "does not raise exception on empty string" false
+            raised;
+          Alcotest.(check bool) "returns Error on empty string" true
+            (CCResult.is_error res));
+      Alcotest.test_case
+        "unpad with pad_len > string length returns Error without raising \
+         exception"
+        `Quick (fun () ->
+          (* "\x10" has length 1, but pad length is 16 *)
+          let raised, res =
+            try (false, Pkcs7.unpad "\x10")
+            with e -> (true, Error (`Msg (Printexc.to_string e)))
+          in
+          Alcotest.(check bool) "does not raise exception on pad_len > len" false
+            raised;
+          Alcotest.(check bool) "returns Error on pad_len > len" true
+            (CCResult.is_error res));
+      Alcotest.test_case "unpad with pad_len = 0 returns Error" `Quick
+        (fun () ->
+          let res = Pkcs7.unpad "hello\x00" in
+          Alcotest.(check bool) "pad_len 0 must be rejected as invalid padding"
+            true (CCResult.is_error res));
+      Alcotest.test_case "unpad with inconsistent padding bytes returns Error"
+        `Quick (fun () ->
+          (* Last byte says 4 bytes of padding, but preceding bytes are \x05 *)
+          let res = Pkcs7.unpad "data\x05\x05\x05\x04" in
+          Alcotest.(check bool)
+            "inconsistent padding bytes must return Error" true
+            (CCResult.is_error res));
+      Alcotest.test_case
+        "pad and unpad roundtrip across varying lengths with block_size 16"
+        `Quick (fun () ->
+          let test_lengths = [ 0; 1; 7; 15; 16; 17; 31; 32; 64; 100 ] in
+          List.iter
+            (fun len ->
+              let input = String.make len 'x' in
+              let padded = Pkcs7.pad input 16 in
+              (* Padded length must always be a multiple of block_size and strictly > input length *)
+              Alcotest.(check int)
+                "padded length is multiple of block size" 0
+                (String.length padded mod 16);
+              Alcotest.(check bool)
+                "padded length is strictly greater than input length" true
+                (String.length padded > String.length input);
+              let unpadded = Pkcs7.unpad padded in
+              Alcotest.(check (result string (testable Fmt.nop ( = ))))
+                "unpadded matches original input" (Ok input) unpadded)
+            test_lengths);
+    ] )
+
+let u_string_tests =
+  ( "U_String",
+    [
+      Alcotest.test_case "rev reverses strings correctly" `Quick (fun () ->
+          Alcotest.(check string) "rev empty" "" (U_String.rev "");
+          Alcotest.(check string) "rev single" "a" (U_String.rev "a");
+          Alcotest.(check string) "rev text" "cba" (U_String.rev "abc"));
+      Alcotest.test_case "split divides strings at correct index" `Quick
+        (fun () ->
+          let left, right = U_String.split "helloworld" 5 in
+          Alcotest.(check string) "left is hello" "hello" left;
+          Alcotest.(check string) "right is world" "world" right);
+      Alcotest.test_case "pad adds leading characters" `Quick (fun () ->
+          let padded = U_String.pad ~c:'0' ~len:5 "123" in
+          Alcotest.(check string) "padded with leading zeros" "00123" padded);
+    ] )
+
+let u_base64_tests =
+  ( "U_Base64",
+    [
+      Alcotest.test_case "url_encode_string and url_decode roundtrip" `Quick
+        (fun () ->
+          let msg = "Hello from OCaml JOSE! ?#$%" in
+          let encoded = U_Base64.url_encode_string msg in
+          let decoded = U_Base64.url_decode encoded |> CCResult.get_exn in
+          Alcotest.(check string) "decoded matches original" msg decoded);
+    ] )
+
+let utils_suite, _ =
+  Junit_alcotest.run_and_report ~package:"jose" "Utils"
+    [ pkcs7_tests; u_string_tests; u_base64_tests ]

--- a/test/test.ml
+++ b/test/test.ml
@@ -10,6 +10,7 @@ let () =
         JWETest.jwe_suite;
         RFC7515.suite;
         RFC7516.suite;
+        RFC7518.suite;
         RFC7520.suite;
         RFC7638.suite;
         RFC8037.suite;

--- a/test/test.ml
+++ b/test/test.ml
@@ -13,6 +13,7 @@ let () =
         RFC7520.suite;
         RFC7638.suite;
         RFC8037.suite;
+        UtilsTest.utils_suite;
       ]
   in
   match path with Some path -> Junit.to_file report path | None -> ()

--- a/test/test.ml
+++ b/test/test.ml
@@ -9,6 +9,7 @@ let () =
         JWTTest.jwt_suite;
         JWETest.jwe_suite;
         RFC7515.suite;
+        RFC7516.suite;
         RFC7520.suite;
         RFC7638.suite;
         RFC8037.suite;


### PR DESCRIPTION
Some fixes to align better with the RFCs

- The IV length was wrong when `enc` is `A256GCM`
- We had some potential for raising in our `unpad` function
- Fix some bad comments
- Constant time string comparison

AI disclosure: The tests were written by Gemini and it was used to go through the RFCs to find issues