### PR TITLE
Align with RFC 9864

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - We had some potential for raising in our unpad function
 - Constant time string comparison everywhere
 - Fix a bug in RSA validation
+- EdDSA is deprecated in rfc 9864, we should use Ed25519 as a less ambiguous name
 
 0.10.0
 --------------

--- a/jose/Header.ml
+++ b/jose/Header.ml
@@ -32,7 +32,7 @@ let make_header ?typ ?alg ?enc ?(extra = []) ?(jwk_header = false)
         | Jwk.Es256_priv _ -> `ES256
         | Jwk.Es384_priv _ -> `ES384
         | Jwk.Es512_priv _ -> `ES512
-        | Jwk.Ed25519_priv _ -> `EdDSA)
+        | Jwk.Ed25519_priv _ -> `Ed25519)
   in
   let kid =
     match List.assoc_opt "kid" extra with
@@ -69,7 +69,7 @@ let of_json json =
         jwk =
           json |> Json.member "jwk"
           |> Json.to_option (fun jwk_json ->
-                 Jwk.of_pub_json jwk_json |> Result.to_option)
+              Jwk.of_pub_json jwk_json |> Result.to_option)
           |> Option.join;
         kid = json |> Json.member "kid" |> Json.to_string_option;
         x5t = json |> Json.member "x5t" |> Json.to_string_option;

--- a/jose/Jose.mli
+++ b/jose/Jose.mli
@@ -11,6 +11,9 @@ module Jwa : sig
     | `EdDSA
         (** EdDSA signature algorithm
             {{:https://www.rfc-editor.org/rfc/rfc8037.html} Link to RFC} *)
+    | `Ed25519
+        (** EdDSA signature algorithm with Ed25519
+            {{:https://www.rfc-editor.org/rfc/rfc9864.html} Link to RFC} *)
     | `RSA_OAEP  (** RSAES OAEP using default parameters *)
     | `RSA1_5  (** RSA PKCS 1 *)
     | `None

--- a/jose/Jwa.ml
+++ b/jose/Jwa.ml
@@ -26,6 +26,7 @@ type alg =
   | `ES384  (** ECDSA using P-384 and SHA-384 *)
   | `ES512  (** ECDSA using P-521 and SHA-512 *)
   | `EdDSA  (** EdDSA signature algorithm *)
+  | `Ed25519  (** Ed25519 signature algorithm (RFC 9864) *)
   | `RSA_OAEP  (** RSAES OAEP using default parameters *)
   | `RSA1_5  (** RSA PKCS 1 *)
   | `None
@@ -38,6 +39,7 @@ let alg_to_string = function
   | `ES384 -> "ES384"
   | `ES512 -> "ES512"
   | `EdDSA -> "EdDSA"
+  | `Ed25519 -> "Ed25519"
   | `RSA_OAEP -> "RSA-OAEP"
   | `RSA1_5 -> "RSA1_5"
   | `None -> "none"
@@ -50,6 +52,7 @@ let alg_of_string = function
   | "ES384" -> `ES384
   | "ES512" -> `ES512
   | "EdDSA" -> `EdDSA
+  | "Ed25519" -> `Ed25519
   | "RSA-OAEP" -> `RSA_OAEP
   | "RSA1_5" -> `RSA1_5
   | "none" -> `None

--- a/jose/Jwk.ml
+++ b/jose/Jwk.ml
@@ -8,7 +8,7 @@ module Util = struct
   let get_component ?(pad = false) e =
     U_Base64.url_decode ~pad e
     |> Result.map (fun x ->
-           U_String.pad ~len:8 ~c:'\000' x |> U_String.rev |> Z.of_bits)
+        U_String.pad ~len:8 ~c:'\000' x |> U_String.rev |> Z.of_bits)
 
   let kid_of_json json =
     Yojson.Safe.to_string json |> Digestif.SHA256.digest_string
@@ -74,7 +74,7 @@ let alg_of_use_and_kty ?(use : use = `Sig) (kty : Jwa.kty) : Jwa.alg =
   | `Sig, `oct -> `HS256
   | `Sig, `RSA -> `RS256
   | `Sig, `EC -> `ES512
-  | `Sig, `OKP -> `EdDSA
+  | `Sig, `OKP -> `Ed25519
   | `Enc, `RSA -> `RSA_OAEP
   | `Enc, `oct -> `Unsupported "encryption with oct is not supported yet"
   | `Enc, `EC ->
@@ -91,7 +91,7 @@ let use_of_alg (alg : Jwa.alg) =
   | `ES256 -> `Sig
   | `ES384 -> `Sig
   | `ES512 -> `Sig
-  | `EdDSA -> `Sig
+  | `EdDSA | `Ed25519 -> `Sig
   | `RSA_OAEP -> `Enc
   | `RSA1_5 -> `Enc
   | `None -> `Unsupported "none"

--- a/jose/Jws.ml
+++ b/jose/Jws.ml
@@ -109,13 +109,13 @@ let verify_jwk (type a) ~(jwk : a Jwk.t) ~input_str signature =
   | Jwk.Rsa_priv jwk -> (
       let pub_jwk = Jwk.pub_of_priv_rsa jwk in
       try (Mirage_crypto_pk.Rsa.PKCS1.verify ~hashp:(rsa_validate_hash ?alg:jwk.alg) ~key:pub_jwk.key ~signature (`Message input_str) |> function
-      | false -> Error (`Msg "payload does not match")
+        | false -> Error (`Msg "payload does not match")
       | true -> Ok signature) with
       | Mirage_crypto_pk.Rsa.Insufficient_key -> Error (`Msg "Insufficient key length")
       | Invalid_argument m -> Error (`Msg m))
   | Jwk.Rsa_pub jwk -> (
       try (Mirage_crypto_pk.Rsa.PKCS1.verify ~hashp:(rsa_validate_hash ?alg:jwk.alg) ~key:jwk.key ~signature (`Message input_str) |> function
-      | false -> Error (`Msg "payload does not match")
+        | false -> Error (`Msg "payload does not match")
       | true -> Ok signature) with
       | Mirage_crypto_pk.Rsa.Insufficient_key -> Error (`Msg "Insufficient key length")
       | Invalid_argument m -> Error (`Msg m))
@@ -210,6 +210,7 @@ let validate (type a) ~(jwk : a Jwk.t) t =
     | `ES384 -> Ok header.alg
     | `ES512 -> Ok header.alg
     | `EdDSA -> Ok header.alg
+    | `Ed25519 -> Ok header.alg
     | `Unsupported _ | `RSA_OAEP | `RSA1_5 | `None ->
         Error (`Msg "alg not supported for signing")
   in
@@ -265,11 +266,11 @@ let sign ?header ~payload (jwk : Jwk.priv Jwk.t) =
     | Jwk.Oct oct ->
         Jwk.oct_to_sign_key oct
         |> Result.map (fun key msg ->
-               match msg with
-               | `Message x ->
-                   Digestif.SHA256.hmac_string ~key x
-                   |> Digestif.SHA256.to_raw_string
-               | `Digest _ -> raise (Invalid_argument "Digest"))
+            match msg with
+            | `Message x ->
+                Digestif.SHA256.hmac_string ~key x
+                |> Digestif.SHA256.to_raw_string
+            | `Digest _ -> raise (Invalid_argument "Digest"))
   in
   match sign_f with
   | Ok sign_f ->

--- a/test/RFC9864.ml
+++ b/test/RFC9864.ml
@@ -1,0 +1,56 @@
+(* Tests for RFC 9864 (Fully-Specified Algorithms for JOSE) *)
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let ed25519_priv_json =
+  {|{"kty":"OKP","crv":"Ed25519","d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}|}
+
+let ed25519_pub_json =
+  {|{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}|}
+
+let ed25519_priv =
+  Jose.Jwk.of_priv_json_string ed25519_priv_json |> CCResult.get_exn
+
+let ed25519_pub =
+  Jose.Jwk.of_pub_json_string ed25519_pub_json |> CCResult.get_exn
+
+let rfc9864_tests =
+  ( "RFC9864",
+    [
+      Alcotest.test_case
+        "RFC 9864: Inbound JWS with alg Ed25519 validates successfully" `Quick
+        (fun () ->
+          let header_json = `Assoc [ ("alg", `String "Ed25519") ] in
+          let header = Jose.Header.of_json header_json |> CCResult.get_exn in
+          let payload = "Example of Ed25519 signing per RFC 9864" in
+          let jws =
+            Jose.Jws.sign ~header ~payload ed25519_priv |> CCResult.get_exn
+          in
+          let validated = Jose.Jws.validate ~jwk:ed25519_pub jws in
+          Alcotest.(check bool) "Ed25519 JWS validates with public key" true
+            (CCResult.is_ok validated));
+      Alcotest.test_case
+        "RFC 9864: Header.make_header emits Ed25519 as default alg for \
+         Ed25519_priv"
+        `Quick (fun () ->
+          let header = Jose.Header.make_header ed25519_priv in
+          let alg_str = Jose.Jwa.alg_to_string header.alg in
+          Alcotest.(check string)
+            "Default algorithm for Ed25519 key must be Ed25519 (RFC 9864)"
+            "Ed25519" alg_str);
+      Alcotest.test_case
+        "RFC 9864: Backward compatibility - deprecated EdDSA algorithm \
+         continues to validate"
+        `Quick (fun () ->
+          let header_json = `Assoc [ ("alg", `String "EdDSA") ] in
+          let header = Jose.Header.of_json header_json |> CCResult.get_exn in
+          let payload = "Legacy EdDSA token" in
+          let jws =
+            Jose.Jws.sign ~header ~payload ed25519_priv |> CCResult.get_exn
+          in
+          let validated = Jose.Jws.validate ~jwk:ed25519_pub jws in
+          Alcotest.(check bool) "Legacy EdDSA JWS validates with public key" true
+            (CCResult.is_ok validated));
+    ] )
+
+let suite, _ =
+  Junit_alcotest.run_and_report ~package:"jose" "RFC9864" [ rfc9864_tests ]

--- a/test/test.ml
+++ b/test/test.ml
@@ -14,6 +14,7 @@ let () =
         RFC7520.suite;
         RFC7638.suite;
         RFC8037.suite;
+        RFC9864.suite;
         UtilsTest.utils_suite;
       ]
   in


### PR DESCRIPTION
- EdDSA is deprecated in rfc 9864, we should use Ed25519 as a less ambiguous name

AI disclosure: The tests were written by Gemini and it was used to go through the RFCs to find issues